### PR TITLE
fix: github_repository_tag_protection deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,5 @@ module "branches" {
   repository              = each.value.name
   default_branch          = lookup(var.repositories, each.value.name).default_branch
   branch_protections      = lookup(var.repositories, each.value.name).branch_protections
-  protected_tags          = lookup(var.repositories, each.value.name).protected_tags
   paid_features_available = var.plan != "free" || lookup(var.repositories, each.value.name).visibility == "public" ? true : false
 }

--- a/modules/branches/main.tf
+++ b/modules/branches/main.tf
@@ -61,10 +61,3 @@ resource "github_branch_protection" "this" {
     }
   }
 }
-
-resource "github_repository_tag_protection" "these" {
-  for_each = var.paid_features_available ? toset(var.protected_tags) : toset([])
-
-  repository = var.repository
-  pattern    = each.value
-}

--- a/modules/branches/variables.tf
+++ b/modules/branches/variables.tf
@@ -35,11 +35,6 @@ variable "branch_protections" {
   }))
 }
 
-variable "protected_tags" {
-  description = "WIP: List of the protected tags to configure"
-  type        = list(string)
-}
-
 variable "paid_features_available" {
   description = "Not all features are available to private repos without paying"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,6 @@ Defines a repo in full. Map of the following object:
     }
 
     visibility         = 'public' or 'private'
-    protected_tags     = List of tags that are to be protected with opinionated rules
 
     branch_protections = Map of branch protections and their settings.
                          See here for specification: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection#argument-reference
@@ -125,8 +124,6 @@ EOF
       lock_branch          = optional(bool, false)
     })), {})
 
-
-    protected_tags = optional(list(string), ["releases/**"])
     collaborators = optional(map(object({
       username                    = string,
       permission                  = optional(string, "pull")


### PR DESCRIPTION
BREAKING CHANGE: The `github_repository_tag_protection` resource (and API endpoints) has been deprecated, meaning it must be removed from anything trying to use it